### PR TITLE
Downgrade upload-artifact and download-artifact from v3 to v2

### DIFF
--- a/.github/workflows/docker-multistage-build.yml
+++ b/.github/workflows/docker-multistage-build.yml
@@ -94,7 +94,7 @@ jobs:
       - name: "[Artifact Load] Download previously built image"
         uses: Wandalen/wretry.action@v1.0.12
         with:
-          action: actions/download-artifact@v3
+          action: actions/download-artifact@v2
           with: |
             name: ${{ steps.set-artifact-name.outputs.prev }}
           attempt_limit: 20
@@ -150,7 +150,7 @@ jobs:
       - name: "[Artifact Save] Upload currently built image"
         uses: Wandalen/wretry.action@v1.0.12
         with:
-          action: actions/upload-artifact@v3
+          action: actions/upload-artifact@v2
           with: |
             name: ${{ steps.set-artifact-name.outputs.curr }}
             path: ${{ steps.set-artifact-name.outputs.curr }}
@@ -163,7 +163,7 @@ jobs:
       ### Verify uploaded image
       ###
       - name: "[Artifact Save] Download (verify)"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v2
         with:
           name: ${{ steps.set-artifact-name.outputs.curr }}
           path: ${{ steps.set-artifact-name.outputs.curr }}.tmp

--- a/.github/workflows/docker-multistage-push-image.yml
+++ b/.github/workflows/docker-multistage-push-image.yml
@@ -98,7 +98,7 @@ jobs:
       - name: "[Artifact Load] Download previously built image"
         uses: Wandalen/wretry.action@v1.0.12
         with:
-          action: actions/download-artifact@v3
+          action: actions/download-artifact@v2
           with: |
             name: ${{ steps.set-artifact-name.outputs.curr }}
           attempt_limit: 20

--- a/.github/workflows/docker-multistage-test.yml
+++ b/.github/workflows/docker-multistage-test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: "[Artifact Load] Download previously built image"
         uses: Wandalen/wretry.action@v1.0.12
         with:
-          action: actions/download-artifact@v3
+          action: actions/download-artifact@v2
           with: |
             name: ${{ steps.set-artifact-name.outputs.curr }}
           attempt_limit: 20


### PR DESCRIPTION
There seem to be many failures with (upload|download)-artifact v3, so downgrading it back to v2 should fix those issues:


* https://github.com/actions/download-artifact/issues/151
* https://github.com/actions/upload-artifact/issues/270